### PR TITLE
Fix list command

### DIFF
--- a/src/main/java/budgetbuddy/BudgetBuddy.java
+++ b/src/main/java/budgetbuddy/BudgetBuddy.java
@@ -18,6 +18,7 @@ import budgetbuddy.ui.UserInterface;
 import java.util.Scanner;
 
 public class BudgetBuddy {
+    public static final int LIST_LENGTH = 5;
     public static final String BYE = "bye";
     public static final String LIST = "list";
     public static final String DELETE = "delete";
@@ -67,7 +68,11 @@ public class BudgetBuddy {
                     isRunning = false;
                     break;
                 case LIST:
-                    transactions.processList(accountManager.getAccounts(), accountManager);
+                    if (input.length() >= LIST_LENGTH) {
+                        UserInterface.printNoCommandExists();
+                    } else {
+                        transactions.processList(accountManager.getAccounts(), accountManager);
+                    }
                     break;
                 case DELETE:
                     transactions.removeTransaction(input, accountManager);


### PR DESCRIPTION
Fix list command to only execute if input is "list" and print "no such command exist" message otherwise.
Fixes #105 